### PR TITLE
Removing Tenant from header and changes in Alert

### DIFF
--- a/proguard/common.pro
+++ b/proguard/common.pro
@@ -1,1 +1,4 @@
 -dontobfuscate
+-keep class org.hawkular.client.android.backend.model.Alert {
+    public <methods>;
+}

--- a/src/main/java/org/hawkular/client/android/backend/BackendPersonnel.java
+++ b/src/main/java/org/hawkular/client/android/backend/BackendPersonnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,6 @@ final class BackendPersonnel implements PipeModule {
         ModuleFields fields = new ModuleFields();
 
         fields.addHeader(BackendPipes.Headers.PERSONA, persona.getId());
-        fields.addHeader(BackendPipes.Headers.TENANT, persona.getId());
 
         return fields;
     }

--- a/src/main/java/org/hawkular/client/android/backend/BackendPipes.java
+++ b/src/main/java/org/hawkular/client/android/backend/BackendPipes.java
@@ -50,8 +50,8 @@ final class BackendPipes {
         public static final String ROOT = "hawkular";
 
         public static final String ALERTS = "alerts";
-        public static final String ALERT_ACKNOWLEDGE = "alerts/ack/%s";
-        public static final String ALERT_RESOLVE = "alerts/resolve/%s";
+        public static final String ALERT_ACKNOWLEDGE = "alerts/ack";
+        public static final String ALERT_RESOLVE = "alerts/resolve";
         public static final String ENVIRONMENTS = "inventory/environments";
         public static final String METRICS = "inventory/%s/resources/%s/metrics";
         public static final String METRIC_DATA_AVAILABILITY= "metrics/availability/%s/data";
@@ -81,6 +81,5 @@ final class BackendPipes {
         }
 
         public static final String PERSONA = "Hawkular-Persona";
-        public static final String TENANT = "Hawkular-Tenant";
     }
 }

--- a/src/main/java/org/hawkular/client/android/backend/model/Alert.java
+++ b/src/main/java/org/hawkular/client/android/backend/model/Alert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,8 @@ package org.hawkular.client.android.backend.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jboss.aerogear.android.core.RecordId;
+
 import com.google.gson.annotations.SerializedName;
 
 import android.os.Parcel;
@@ -27,7 +29,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
 public final class Alert implements Parcelable {
-    @SerializedName("alertId")
+    @RecordId
+    @SerializedName("id")
     private String id;
 
     @SerializedName("ctime")
@@ -45,6 +48,10 @@ public final class Alert implements Parcelable {
 
     public String getId() {
         return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public long getTimestamp() {

--- a/src/main/java/org/hawkular/client/android/fragment/AlertsFragment.java
+++ b/src/main/java/org/hawkular/client/android/fragment/AlertsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -207,7 +207,7 @@ public final class AlertsFragment extends Fragment implements AlertsAdapter.Aler
         List<Trigger> filteredTriggers = new ArrayList<>();
 
         for (Trigger trigger : triggers) {
-            if (trigger.getId().startsWith(resource.getId())) {
+            if (trigger.getId().endsWith(resource.getId())) {
                 filteredTriggers.add(trigger);
             }
         }


### PR DESCRIPTION
Aerogear accepts URI with GET in pipe, but not with PUT or POST.
So Complete URL are used for an alert ack and resolve.

New method savePipe is for providing general POST and PUT.

TENANT is no longer needed to be specified in the header

Complete treatment for the list of triggers connected to resource still in progress.
