### PR TITLE
Change in trigger identification for resources

### DIFF
--- a/src/androidTest/java/org/hawkular/client/android/backend/model/TriggerTester.java
+++ b/src/androidTest/java/org/hawkular/client/android/backend/model/TriggerTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,9 @@
  */
 package org.hawkular.client.android.backend.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.assertj.core.api.Assertions;
 import org.hawkular.client.android.util.Parceler;
 import org.hawkular.client.android.util.Randomizer;
@@ -28,7 +31,9 @@ import android.support.test.runner.AndroidJUnit4;
 public final class TriggerTester {
     @Test
     public void parcelable() {
-        Trigger originalTrigger = new Trigger(Randomizer.generateString());
+        Map<String, String> test = new HashMap<>();
+        test.put(Randomizer.generateString(), Randomizer.generateString());
+        Trigger originalTrigger = new Trigger(Randomizer.generateString(), test);
         Trigger parceledTrigger = Parceler.parcel(Trigger.CREATOR, originalTrigger);
 
         Assertions.assertThat(parceledTrigger.getId()).isEqualTo(originalTrigger.getId());

--- a/src/main/java/org/hawkular/client/android/backend/model/Trigger.java
+++ b/src/main/java/org/hawkular/client/android/backend/model/Trigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
  */
 package org.hawkular.client.android.backend.model;
 
+import java.util.Map;
+
 import com.google.gson.annotations.SerializedName;
 
 import android.os.Parcel;
@@ -26,14 +28,21 @@ import android.support.annotation.VisibleForTesting;
 public final class Trigger implements Parcelable {
     @SerializedName("id")
     private String id;
+    @SerializedName("tags")
+    private Map<String, String> tags;
 
     public String getId() {
         return id;
     }
 
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
     @VisibleForTesting
-    public Trigger(@NonNull String id) {
+    public Trigger(@NonNull String id, @NonNull Map<String, String> tags) {
         this.id = id;
+        this.tags = tags;
     }
 
     public static Creator<Trigger> CREATOR = new Creator<Trigger>() {
@@ -55,6 +64,7 @@ public final class Trigger implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeString(id);
+        parcel.writeMap(tags);
     }
 
     @Override

--- a/src/main/java/org/hawkular/client/android/fragment/AlertsFragment.java
+++ b/src/main/java/org/hawkular/client/android/fragment/AlertsFragment.java
@@ -47,7 +47,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.PopupMenu;
-
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -207,7 +206,8 @@ public final class AlertsFragment extends Fragment implements AlertsAdapter.Aler
         List<Trigger> filteredTriggers = new ArrayList<>();
 
         for (Trigger trigger : triggers) {
-            if (trigger.getId().endsWith(resource.getId())) {
+            if (trigger.getTags() != null
+                    && trigger.getTags().get("resourceId").equals(resource.getId())) {
                 filteredTriggers.add(trigger);
             }
         }


### PR DESCRIPTION
Trigger ID can now be independent of resource ID.
So using the tag to identify it.
